### PR TITLE
NoStack: Ignore Supernatural Innate Effects (Feat, Race, SkillRanks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - DotNET: Added `NWNX_DOTNET_NEW_BOOTSTRAP` option to enable a new bootstrap method with less boilerplate code.
 - DotNET: Added `RequestFunctionHook`, `ReturnFunctionHook`.
 - Events: Added events `NWNX_ON_SET_EXPERIENCE_{BEFORE|AFTER}` which fire when the XP of a player changes.
+- NoStack: Added `NWNX_NOSTACK_IGNORE_SUPERNATURAL_INNATE` to ignore effects created by the Feat, Race and SkillRanks plugins when stacking.
 
 ##### New Plugins
 - Store: Enables getting and setting store data.

--- a/Plugins/NoStack/README.md
+++ b/Plugins/NoStack/README.md
@@ -10,6 +10,7 @@ Functions and variables to control stacking of multiple bonuses of the same type
 * `NWNX_NOSTACK_ITEM_DEFAULT_TYPE`: Between 0 and 20. See below.
 * `NWNX_NOSTACK_ALWAYS_STACK_PENALTIES`: true or false. Defaults to false.
 * `NWNX_NOSTACK_SEPARATE_INVALID_OID_EFFECTS`: true or false. Defaults to false.
+* `NWNX_NOSTACK_IGNORE_SUPERNATURAL_INNATE`: true or false. Defaults to false.
 
 ### NWNX_NOSTACK_*
 
@@ -60,3 +61,7 @@ This is needed because scripted effects, unless created from a spellscript, alwa
 This is a quick fix, if you want to control each of the scripted effect types you will need to unpack the effect, set a valid spellId and use the
 `SetSpellBonusType()` function to set the bonus for that spellId. The spellId has to be a valid spell, so either reuse one of the existing spells
 that don't give a bonus effect (i.e. healing or damaging spells) or add a dummy spell to your spells.2da.
+
+### NWNX_NOSTACK_IGNORE_SUPERNATURAL_INNATE
+Set this value to true if you want to ignore your stacking rules for Supernatural Innate effects. This is the type of effect used in the
+Race, SkillRanks and Feat plugins.


### PR DESCRIPTION
This offers the option to set `NWNX_NOSTACK_IGNORE_SUPERNATURAL_INNATE` to `true` so your NoStack rules are ignored for effects granted through the Feat, Race and SkillRanks plugins.

These plugins set the subtype to `Constants::EffectSubType::Supernatural | Constants::EffectDurationType::Innate` on the effects granted.

This also corrects an issue when NoStack `GetTotalEffectBonus` hook was not increasing max caps for ability bonuses granted via the other plugins.