### PR TITLE
fix(layonara): re-apply quiver body VFX when stripped mid-session

### DIFF
--- a/Plugins/Layonara/Layonara.cpp
+++ b/Plugins/Layonara/Layonara.cpp
@@ -156,11 +156,46 @@ void Layonara::RemoveEffectByTag(CNWSCreature *pCreature, std::string sCustomTag
         pCreature->RemoveEffectById(id);
 }
 
+bool Layonara::HasEffectByTag(CNWSCreature *pCreature, const char* tag)
+{
+    for (int i = pCreature->m_appliedEffects.num - 1; i >= 0; i--)
+    {
+        if (((CGameEffect*)pCreature->m_appliedEffects.element[i])->m_sCustomTag == CExoString(tag))
+            return true;
+    }
+    return false;
+}
+
 void Layonara::SetArrowsEffect(CNWSCreature *pCreature, bool bOff)
 {
     RemoveEffectByTag(pCreature, "NWNX_Layonara_QuiverArrows");
     if (bOff)
         return;
+
+    if (!HasEffectByTag(pCreature, "NWNX_Layonara_Quiver"))
+    {
+        int nColor = pCreature->m_ScriptVars.GetInt(CExoString("NWNX_Quiver_Color"));
+        if (nColor > 0)
+        {
+            const uint16_t quiverFXStart = 1084;
+            auto racialType = pCreature->m_pStats->m_nRace;
+            auto raceOffset = racialType;
+            if (racialType == 4 || racialType == 6)
+                raceOffset = 5;
+            else if (racialType == 5)
+                raceOffset = 4;
+
+            auto *eff = new CGameEffect(true);
+            eff->m_oidCreator         = 0;
+            eff->m_nType              = EffectTrueType::VisualEffect;
+            eff->m_nSubType           = EffectSubType::Supernatural | EffectDurationType::Innate;
+            eff->m_bShowIcon          = 0;
+            eff->m_nParamInteger[0]   = quiverFXStart + (nColor * 12) + (raceOffset * 2) + pCreature->m_pStats->m_nGender;
+            eff->m_sCustomTag         = "NWNX_Layonara_Quiver";
+            eff->m_bExpose            = true;
+            pCreature->ApplyEffect(eff, true, true);
+        }
+    }
 
     auto pItem = pCreature->m_pInventory->GetItemInSlot(Constants::EquipmentSlot::Arrows);
 
@@ -757,6 +792,7 @@ ArgumentStack Layonara::SetQuiver(ArgumentStack&& args)
 
     if (nColor == -1)
     {
+        pCreature->m_ScriptVars.DestroyInt(CExoString("NWNX_Quiver_Color"));
         SetArrowsEffect(pCreature, true);
         return stack;
     }
@@ -778,6 +814,8 @@ ArgumentStack Layonara::SetQuiver(ArgumentStack&& args)
     eff->m_sCustomTag         = "NWNX_Layonara_Quiver";
     eff->m_bExpose            = true;
     pCreature->ApplyEffect(eff, true, true);
+
+    pCreature->m_ScriptVars.SetInt(CExoString("NWNX_Quiver_Color"), nColor);
 
     SetArrowsEffect(pCreature);
 

--- a/Plugins/Layonara/Layonara.cpp
+++ b/Plugins/Layonara/Layonara.cpp
@@ -174,7 +174,8 @@ void Layonara::SetArrowsEffect(CNWSCreature *pCreature, bool bOff)
 
     if (!HasEffectByTag(pCreature, "NWNX_Layonara_Quiver"))
     {
-        int nColor = pCreature->m_ScriptVars.GetInt(CExoString("NWNX_Quiver_Color"));
+        CExoString sQuiverColor("NWNX_Quiver_Color");
+        int nColor = pCreature->m_ScriptVars.GetInt(sQuiverColor);
         if (nColor > 0)
         {
             const uint16_t quiverFXStart = 1084;
@@ -792,7 +793,8 @@ ArgumentStack Layonara::SetQuiver(ArgumentStack&& args)
 
     if (nColor == -1)
     {
-        pCreature->m_ScriptVars.DestroyInt(CExoString("NWNX_Quiver_Color"));
+        CExoString sKey("NWNX_Quiver_Color");
+        pCreature->m_ScriptVars.DestroyInt(sKey);
         SetArrowsEffect(pCreature, true);
         return stack;
     }
@@ -815,7 +817,8 @@ ArgumentStack Layonara::SetQuiver(ArgumentStack&& args)
     eff->m_bExpose            = true;
     pCreature->ApplyEffect(eff, true, true);
 
-    pCreature->m_ScriptVars.SetInt(CExoString("NWNX_Quiver_Color"), nColor);
+    CExoString sColorKey("NWNX_Quiver_Color");
+    pCreature->m_ScriptVars.SetInt(sColorKey, nColor);
 
     SetArrowsEffect(pCreature);
 

--- a/Plugins/Layonara/Layonara.hpp
+++ b/Plugins/Layonara/Layonara.hpp
@@ -18,6 +18,7 @@ public:
 
 private:
     static void RemoveEffectByTag(CNWSCreature *pCreature, std::string sCustomTag);
+    static bool HasEffectByTag(CNWSCreature *pCreature, const char* tag);
     static void SetArrowsEffect(CNWSCreature *pCreature, bool bOff=false);
     static CNWSItem *GetItemInSlotHook(CNWSInventory*, uint32_t);
     static void SetPositionHook(CNWSObject*, Vector, int32_t);


### PR DESCRIPTION
## Summary
- Quiver body mesh (`NWNX_Layonara_Quiver`) was lost when stripped by rest, death, polymorph, or mount/dismount — arrows kept refreshing but the body did not
- Store quiver color on creature via `m_ScriptVars` in `SetQuiver`, read it back in `SetArrowsEffect` to re-apply the body if missing
- Add `HasEffectByTag` helper for the presence check

Closes layonara/nwn-module#196

## Test plan
- [ ] `;quiver green` — both body and arrows appear
- [ ] Mount/dismount horse — quiver body returns after dismount
- [ ] Die and respawn — quiver body re-appears on next equip change
- [ ] `;quiver none` — both body and arrows removed
- [ ] Login with quiver set — both appear (regression check)