### PR TITLE
fix: remove DIRT from surface speed map and tileset exclusions

### DIFF
--- a/Plugins/Layonara/Layonara.cpp
+++ b/Plugins/Layonara/Layonara.cpp
@@ -112,8 +112,6 @@ Layonara::Layonara(Services::ProxyServiceList* services)
     m_PhysicalDamageTypes.push_back(DamageType::Piercing);
     m_PhysicalDamageTypes.push_back(DamageType::Slashing);
 
-    m_SurfaceMaterialSpeeds[SurfaceMaterials::DIRT] = 33;
-    // m_SurfaceMaterialSpeeds[SurfaceMaterials::STONE] = 33;
     m_SurfaceMaterialSpeeds[SurfaceMaterials::DIRTPATH] = 33;
     m_SurfaceMaterialSpeeds[SurfaceMaterials::STONEPATH] = 33;
     m_SurfaceMaterialSpeeds[SurfaceMaterials::WATER] = -25;
@@ -891,7 +889,7 @@ void Layonara::SetPositionHook(CNWSObject* thisPtr, Vector vPos, int32_t bDoingC
             return;
         }
         auto pArea = pServer->GetAreaByGameObjectID(thisPtr->m_oidArea);
-        if (pArea == nullptr || pArea->m_refTileSet == "ttu01" || pArea->m_refTileSet == "tcr10" || pArea->m_refTileSet == "tbm01")
+        if (pArea == nullptr)
         {
             s_setPositionHook->CallOriginal<void>(thisPtr, vPos, bDoingCharacterCopy);
             return;


### PR DESCRIPTION
## Summary
- Remove `DIRT (1)` from `m_SurfaceMaterialSpeeds` — only `DIRTPATH (28)` and `STONEPATH (29)` get +33% road speed
- Remove `ttu01`/`tcr10`/`tbm01` tileset exclusions from `SetPositionHook` — bandaids for incorrect walkmesh paint

Companion: layonara/nwn-haks#10 repaints all walkmesh road surfaces correctly.